### PR TITLE
Feat: add icons documentation

### DIFF
--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -21,6 +21,10 @@ const navigation = buildSidebarNav(
       text: "Tokens",
     },
     {
+      link: "/icons/",
+      text: "Icons",
+    },
+    {
       link: "/meteor-components/form/mt-field-label.md",
       text: "Components",
     },

--- a/src/components/icons/IconDisplay.vue
+++ b/src/components/icons/IconDisplay.vue
@@ -1,0 +1,62 @@
+<template>
+  <a href="#" class="IconDisplay" :class="mode ? `--mode-${mode}` : null" @click.prevent.stop="$emit('select')">
+    <div class="IconDisplay_wrap">
+      <SwagIcon class="IconDisplay_icon" :icon="icon.name" :type="icon.mode" />
+      <span v-if="mode === 'inline'" class="IconDisplay_name">{{ icon.name }}</span>
+    </div>
+    <span v-if="mode !== 'inline'" class="IconDisplay_name">{{ icon.name }}</span>
+  </a>
+</template>
+
+<script setup>
+import {computed} from 'vue';
+
+const props = defineProps({
+  icon: Object,
+  mode: Object
+})
+
+const id = computed(() => {
+  return `meteor-icon-kit__${props.icon.mode}-${props.icon.name}`;
+});
+</script>
+
+<style lang="scss">
+.IconDisplay {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: .5rem;
+  color: var(--vp-c-text);
+  &_name,
+  &_icon {
+    color: var(--vp-c-text);
+  }
+  &_name {
+    @apply text-xs font-medium;
+  }
+  &_wrap {
+    @apply bg-[var(--sw-c-gray-50)] flex items-center justify-center;
+    width: 100%;
+    .dark & {
+      @apply bg-[var(--sw-c-gray-dark-700)];
+    }
+  }
+  &.--mode-inline {
+    flex-direction: row;
+    .IconDisplay_wrap {
+      @apply p-4 items-center gap-2;
+      justify-content: flex-start;
+      --icon-size: 1.725rem;
+    }
+  }
+  &:not(.--mode-inline) {
+    .IconDisplay_wrap {
+      aspect-ratio: 1;
+      --icon-size: 1.5rem;
+    }
+  }
+}
+</style>

--- a/src/components/icons/IconDisplay.vue
+++ b/src/components/icons/IconDisplay.vue
@@ -1,20 +1,29 @@
 <template>
-  <a href="#" class="IconDisplay" :class="mode ? `--mode-${mode}` : null" @click.prevent.stop="$emit('select')">
+  <a
+    href="#"
+    class="IconDisplay"
+    :class="mode ? `--mode-${mode}` : null"
+    @click.prevent.stop="$emit('select')"
+  >
     <div class="IconDisplay_wrap">
       <SwagIcon class="IconDisplay_icon" :icon="icon.name" :type="icon.mode" />
-      <span v-if="mode === 'inline'" class="IconDisplay_name">{{ icon.name }}</span>
+      <span v-if="mode === 'inline'" class="IconDisplay_name">{{
+        icon.name
+      }}</span>
     </div>
-    <span v-if="mode !== 'inline'" class="IconDisplay_name">{{ icon.name }}</span>
+    <span v-if="mode !== 'inline'" class="IconDisplay_name">{{
+      icon.name
+    }}</span>
   </a>
 </template>
 
 <script setup>
-import {computed} from 'vue';
+import { computed } from "vue";
 
 const props = defineProps({
   icon: Object,
-  mode: Object
-})
+  mode: Object,
+});
 
 const id = computed(() => {
   return `meteor-icon-kit__${props.icon.mode}-${props.icon.name}`;
@@ -28,7 +37,7 @@ const id = computed(() => {
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  gap: .5rem;
+  gap: 0.5rem;
   color: var(--vp-c-text);
   &_name,
   &_icon {

--- a/src/components/icons/IconDisplay.vue
+++ b/src/components/icons/IconDisplay.vue
@@ -30,7 +30,7 @@ const id = computed(() => {
 });
 </script>
 
-<style lang="scss">
+<style lang="css">
 .IconDisplay {
   display: flex;
   width: 100%;
@@ -39,33 +39,44 @@ const id = computed(() => {
   flex-direction: column;
   gap: 0.5rem;
   color: var(--vp-c-text);
-  &_name,
-  &_icon {
-    color: var(--vp-c-text);
-  }
-  &_name {
-    @apply text-xs font-medium;
-  }
-  &_wrap {
-    @apply bg-[var(--sw-c-gray-50)] flex items-center justify-center;
-    width: 100%;
-    .dark & {
-      @apply bg-[var(--sw-c-gray-dark-700)];
-    }
-  }
-  &.--mode-inline {
-    flex-direction: row;
-    .IconDisplay_wrap {
-      @apply p-4 items-center gap-2;
-      justify-content: flex-start;
-      --icon-size: 1.725rem;
-    }
-  }
-  &:not(.--mode-inline) {
-    .IconDisplay_wrap {
-      aspect-ratio: 1;
-      --icon-size: 1.5rem;
-    }
-  }
+}
+
+.IconDisplay_name,
+.IconDisplay_icon {
+  color: var(--vp-c-text);
+}
+
+.IconDisplay_name {
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.IconDisplay_wrap {
+  background-color: var(--sw-c-gray-50);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+:root[class~="dark"] .IconDisplay_wrap {
+  background-color: var(--sw-c-gray-dark-700);
+}
+
+.IconDisplay.--mode-inline {
+  flex-direction: row;
+}
+
+.IconDisplay.--mode-inline .IconDisplay_wrap {
+  padding: 1rem;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: flex-start;
+  --icon-size: 1.725rem;
+}
+
+.IconDisplay:not(.--mode-inline) .IconDisplay_wrap {
+  aspect-ratio: 1;
+  --icon-size: 1.5rem;
 }
 </style>

--- a/src/components/icons/IconDisplay.vue
+++ b/src/components/icons/IconDisplay.vue
@@ -30,7 +30,7 @@ const id = computed(() => {
 });
 </script>
 
-<style lang="css">
+<style lang="css" scoped>
 .IconDisplay {
   display: flex;
   width: 100%;

--- a/src/components/icons/IconSelection.vue
+++ b/src/components/icons/IconSelection.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="IconSelection_bg" @click.prevent="$emit('switch', null)"/>
+  <div class="IconSelection" v-bind="$attrs">
+    <div class="IconSelection_sidebar-bg">
+      <!--<a class="IconSelection_close" href="#"
+         @click.prevent="$emit('switch', null)">Close</a>-->
+
+      <!--<a :href="`${embedPoint}${icon.mode}/${icon.name}.svg`" class="btn --secondary" download>Download .svg</a>-->
+      <div class="flex flex-col gap-4">
+        <div class="flex gap-4 items-center">
+          <SwagIcon class="--medium" :icon="icon.name" :type="icon.mode" />
+          <SwagIcon class="--small" :icon="icon.name" :type="icon.mode" />
+        </div>
+
+        <div class="flex gap-4 justify-center">
+          <SwagIcon class="--large" :icon="icon.name" :type="icon.mode" />
+        </div>
+      </div>
+    </div>
+
+    <h1 @click.prevent="copyIconName">{{ icon.name }}</h1>
+    <div class="IconSelection_tags" v-if="icon.tags.length">
+      <span class="IconSelection_tag btn --subtle --xs --with-border" v-for="tag in icon.tags">{{ tag }}</span>
+    </div>
+
+    <!--<div>
+      <h4>Sizes</h4>
+      <p v-if="false && icon.sizes.length === 1">The icon is available in one size.</p>
+      <div v-else class="flex gap-2">
+        <button v-for="size in icon.sizes"
+                type="button"
+                @click.prevent="$emit('switch', {mode: icon.mode, basename: icon.basename, size})"
+                :class="size === icon.size ? '--secondary' : '--subtle'"
+                class="btn --secondary --xs">{{ size || 'default' }}
+        </button>
+      </div>
+    </div>
+
+    <div>
+      <h4>Styles</h4>
+      <p v-if="false && icon.modes.length === 1">The icon is available in one style.</p>
+      <div v-else class="flex gap-2">
+        <button v-for="mode in icon.modes"
+                type="button"
+                @click.prevent="$emit('switch', {mode, basename: icon.basename, size: icon.size})"
+                :class="mode === icon.mode ? '--secondary' : '--subtle'"
+                class="btn --secondary --xs">{{ mode }}
+        </button>
+      </div>
+    </div>-->
+
+    <div>
+      <!--<h4>Examples</h4>-->
+      <textarea class="form-control" v-model="exampleHTML"></textarea>
+    </div>
+
+    <div>
+      <h2>Related icons</h2>
+      <div class="IconSelection_list">
+        <IconDisplay
+            v-for="icon in icons.slice(0, 4)"
+            :key="icon"
+            :icon="icon"
+            mode="inline"
+            @select="$emit('switch', icon)"/>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<style lang="scss">
+.IconSelection {
+  @apply grid gap-6;
+  &_tags {
+    @apply flex flex-row gap-2;
+  }
+
+  &_tag {
+    @apply bg-[var(--sw-c-gray-100)] text-[var(--sw-c-gray-dark-500)] text-sm px-2 py-1;
+  }
+
+  &_close {
+    @apply absolute right-0 top-0 mr-8 mt-8;
+  }
+
+  &_list {
+    @apply grid gap-6;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &_sidebar-bg {
+    @apply p-6 bg-[var(--sw-c-gray-50)];
+    .dark & {
+      @apply bg-[var(--sw-c-gray-dark-700)]
+    }
+  }
+
+  .SwagIcon {
+    &.--small {
+      --icon-size: 1rem;
+    }
+    &.--medium {
+      --icon-size: 1.725rem;
+    }
+    &.--large {
+      --icon-size: 8rem;
+    }
+  }
+
+  @media (max-width: 960.5px) {
+    position: fixed;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    top: 50%;
+    max-height: 75vh;
+    max-width: 75vw;
+    overflow: auto;
+    z-index: 101;
+
+    &_bg {
+      position: fixed;
+      content: '';
+      display: block;
+      background: rgba(0, 0, 0, 0.333);
+      inset: 0;
+      z-index: 100;
+    }
+  }
+
+  @media (min-width: 960.5px) {
+    position: sticky;
+    top: calc(var(--vp-nav-height) + 1rem);
+    &_bg {
+      display: none;
+    }
+  }
+}
+</style>
+
+<script setup>
+import {computed} from "vue";
+import IconDisplay from "./IconDisplay.vue"
+
+const props = defineProps({
+  icon: {},
+  icons: {}
+});
+
+const exampleHTML = computed(() => props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null);
+const exampleVue2 = computed(() => props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null);
+const exampleVue3 = computed(() => props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null);
+const exampleReact = computed(() => props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null);
+
+const copyIconName = () => {
+  const tempTextArea = document.createElement('textarea');
+  tempTextArea.value = `${props.icon.regular ? 'regular-' : 'solid-'}${props.icon.name}`;
+  document.body.appendChild(tempTextArea);
+  tempTextArea.select();
+  document.execCommand('copy');
+  document.body.removeChild(tempTextArea);
+}
+
+const embedPoint = '/resources/meteor-icon-kit/public/icons/';
+</script>

--- a/src/components/icons/IconSelection.vue
+++ b/src/components/icons/IconSelection.vue
@@ -92,7 +92,7 @@ const copyIconName = () => {
 const embedPoint = "/resources/meteor-icon-kit/public/icons/";
 </script>
 
-<style lang="css">
+<style lang="css" scoped>
 .IconSelection {
   display: grid;
   gap: 1.5rem;

--- a/src/components/icons/IconSelection.vue
+++ b/src/components/icons/IconSelection.vue
@@ -2,10 +2,10 @@
   <div class="IconSelection_bg" @click.prevent="$emit('switch', null)" />
   <div class="IconSelection" v-bind="$attrs">
     <div class="IconSelection_sidebar-bg">
-      <!--<a class="IconSelection_close" href="#"
-         @click.prevent="$emit('switch', null)">Close</a>-->
+      <!--<a class="IconSelection_close" href="#" @click.prevent="$emit('switch', null)">Close</a>-->
 
-      <!--<a :href="`${embedPoint}${icon.mode}/${icon.name}.svg`" class="btn --secondary" download>Download .svg</a>-->
+      <!-- <a :href="`${embedPoint}${icon.mode}/${icon.name}.svg`" class="btn --secondary" download>Download .svg</a> -->
+
       <div class="flex flex-col gap-4">
         <div class="flex gap-4 items-center">
           <SwagIcon class="--medium" :icon="icon.name" :type="icon.mode" />
@@ -21,40 +21,14 @@
     <h1 @click.prevent="copyIconName">{{ icon.name }}</h1>
     <div class="IconSelection_tags" v-if="icon.tags.length">
       <span
-        class="IconSelection_tag btn --subtle --xs --with-border"
         v-for="tag in icon.tags"
+        :key="tag"
+        class="IconSelection_tag btn --subtle --xs --with-border"
         >{{ tag }}</span
       >
     </div>
 
-    <!--<div>
-      <h4>Sizes</h4>
-      <p v-if="false && icon.sizes.length === 1">The icon is available in one size.</p>
-      <div v-else class="flex gap-2">
-        <button v-for="size in icon.sizes"
-                type="button"
-                @click.prevent="$emit('switch', {mode: icon.mode, basename: icon.basename, size})"
-                :class="size === icon.size ? '--secondary' : '--subtle'"
-                class="btn --secondary --xs">{{ size || 'default' }}
-        </button>
-      </div>
-    </div>
-
     <div>
-      <h4>Styles</h4>
-      <p v-if="false && icon.modes.length === 1">The icon is available in one style.</p>
-      <div v-else class="flex gap-2">
-        <button v-for="mode in icon.modes"
-                type="button"
-                @click.prevent="$emit('switch', {mode, basename: icon.basename, size: icon.size})"
-                :class="mode === icon.mode ? '--secondary' : '--subtle'"
-                class="btn --secondary --xs">{{ mode }}
-        </button>
-      </div>
-    </div>-->
-
-    <div>
-      <!--<h4>Examples</h4>-->
       <textarea class="form-control" v-model="exampleHTML"></textarea>
     </div>
 
@@ -73,74 +47,6 @@
   </div>
 </template>
 
-<style lang="scss">
-.IconSelection {
-  @apply grid gap-6;
-  &_tags {
-    @apply flex flex-row gap-2;
-  }
-
-  &_tag {
-    @apply bg-[var(--sw-c-gray-100)] text-[var(--sw-c-gray-dark-500)] text-sm px-2 py-1;
-  }
-
-  &_close {
-    @apply absolute right-0 top-0 mr-8 mt-8;
-  }
-
-  &_list {
-    @apply grid gap-6;
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  &_sidebar-bg {
-    @apply p-6 bg-[var(--sw-c-gray-50)];
-    .dark & {
-      @apply bg-[var(--sw-c-gray-dark-700)];
-    }
-  }
-
-  .SwagIcon {
-    &.--small {
-      --icon-size: 1rem;
-    }
-    &.--medium {
-      --icon-size: 1.725rem;
-    }
-    &.--large {
-      --icon-size: 8rem;
-    }
-  }
-
-  @media (max-width: 960.5px) {
-    position: fixed;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    top: 50%;
-    max-height: 75vh;
-    max-width: 75vw;
-    overflow: auto;
-    z-index: 101;
-
-    &_bg {
-      position: fixed;
-      content: "";
-      display: block;
-      background: rgba(0, 0, 0, 0.333);
-      inset: 0;
-      z-index: 100;
-    }
-  }
-
-  @media (min-width: 960.5px) {
-    position: sticky;
-    top: calc(var(--vp-nav-height) + 1rem);
-    &_bg {
-      display: none;
-    }
-  }
-}
-</style>
 
 <script setup>
 import { computed } from "vue";
@@ -177,3 +83,91 @@ const copyIconName = () => {
 
 const embedPoint = "/resources/meteor-icon-kit/public/icons/";
 </script>
+
+<style lang="css">
+.IconSelection {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.IconSelection_tags {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+}
+
+.IconSelection_tag {
+  background-color: var(--sw-c-gray-100);
+  color: var(--sw-c-gray-dark-500);
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.IconSelection_close {
+  position: absolute;
+  right: 0;
+  top: 0;
+  margin-right: 2rem;
+  margin-top: 2rem;
+}
+
+.IconSelection_list {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.IconSelection_sidebar-bg {
+  padding: 1.5rem;
+  background-color: var(--sw-c-gray-50);
+}
+
+.dark .IconSelection_sidebar-bg {
+  background-color: var(--sw-c-gray-dark-700);
+}
+
+.IconSelection .SwagIcon.--small {
+  --icon-size: 1rem;
+}
+
+.IconSelection .SwagIcon.--medium {
+  --icon-size: 1.725rem;
+}
+
+.IconSelection .SwagIcon.--large {
+  --icon-size: 8rem;
+}
+
+@media (max-width: 960.5px) {
+  .IconSelection {
+    position: fixed;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    top: 50%;
+    max-height: 75vh;
+    max-width: 75vw;
+    overflow: auto;
+    z-index: 101;
+  }
+
+  .IconSelection_bg {
+    position: fixed;
+    content: "";
+    display: block;
+    background: rgba(0, 0, 0, 0.333);
+    inset: 0;
+    z-index: 100;
+  }
+}
+
+@media (min-width: 960.5px) {
+  .IconSelection {
+    position: sticky;
+    top: calc(var(--vp-nav-height) + 1rem);
+  }
+
+  .IconSelection_bg {
+    display: none;
+  }
+}
+</style>

--- a/src/components/icons/IconSelection.vue
+++ b/src/components/icons/IconSelection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="IconSelection_bg" @click.prevent="$emit('switch', null)"/>
+  <div class="IconSelection_bg" @click.prevent="$emit('switch', null)" />
   <div class="IconSelection" v-bind="$attrs">
     <div class="IconSelection_sidebar-bg">
       <!--<a class="IconSelection_close" href="#"
@@ -20,7 +20,11 @@
 
     <h1 @click.prevent="copyIconName">{{ icon.name }}</h1>
     <div class="IconSelection_tags" v-if="icon.tags.length">
-      <span class="IconSelection_tag btn --subtle --xs --with-border" v-for="tag in icon.tags">{{ tag }}</span>
+      <span
+        class="IconSelection_tag btn --subtle --xs --with-border"
+        v-for="tag in icon.tags"
+        >{{ tag }}</span
+      >
     </div>
 
     <!--<div>
@@ -58,14 +62,14 @@
       <h2>Related icons</h2>
       <div class="IconSelection_list">
         <IconDisplay
-            v-for="icon in icons.slice(0, 4)"
-            :key="icon"
-            :icon="icon"
-            mode="inline"
-            @select="$emit('switch', icon)"/>
+          v-for="icon in icons.slice(0, 4)"
+          :key="icon"
+          :icon="icon"
+          mode="inline"
+          @select="$emit('switch', icon)"
+        />
       </div>
     </div>
-
   </div>
 </template>
 
@@ -92,7 +96,7 @@
   &_sidebar-bg {
     @apply p-6 bg-[var(--sw-c-gray-50)];
     .dark & {
-      @apply bg-[var(--sw-c-gray-dark-700)]
+      @apply bg-[var(--sw-c-gray-dark-700)];
     }
   }
 
@@ -120,7 +124,7 @@
 
     &_bg {
       position: fixed;
-      content: '';
+      content: "";
       display: block;
       background: rgba(0, 0, 0, 0.333);
       inset: 0;
@@ -139,27 +143,37 @@
 </style>
 
 <script setup>
-import {computed} from "vue";
-import IconDisplay from "./IconDisplay.vue"
+import { computed } from "vue";
+import IconDisplay from "./IconDisplay.vue";
 
 const props = defineProps({
   icon: {},
-  icons: {}
+  icons: {},
 });
 
-const exampleHTML = computed(() => props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null);
-const exampleVue2 = computed(() => props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null);
-const exampleVue3 = computed(() => props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null);
-const exampleReact = computed(() => props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null);
+const exampleHTML = computed(() =>
+  props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null
+);
+const exampleVue2 = computed(() =>
+  props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null
+);
+const exampleVue3 = computed(() =>
+  props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null
+);
+const exampleReact = computed(() =>
+  props.icon ? `<sw-icon name="${props.icon.mode}-${props.icon.name}" />` : null
+);
 
 const copyIconName = () => {
-  const tempTextArea = document.createElement('textarea');
-  tempTextArea.value = `${props.icon.regular ? 'regular-' : 'solid-'}${props.icon.name}`;
+  const tempTextArea = document.createElement("textarea");
+  tempTextArea.value = `${props.icon.regular ? "regular-" : "solid-"}${
+    props.icon.name
+  }`;
   document.body.appendChild(tempTextArea);
   tempTextArea.select();
-  document.execCommand('copy');
+  document.execCommand("copy");
   document.body.removeChild(tempTextArea);
-}
+};
 
-const embedPoint = '/resources/meteor-icon-kit/public/icons/';
+const embedPoint = "/resources/meteor-icon-kit/public/icons/";
 </script>

--- a/src/components/icons/IconSelection.vue
+++ b/src/components/icons/IconSelection.vue
@@ -2,9 +2,12 @@
   <div class="IconSelection_bg" @click.prevent="$emit('switch', null)" />
   <div class="IconSelection" v-bind="$attrs">
     <div class="IconSelection_sidebar-bg">
-      <!--<a class="IconSelection_close" href="#" @click.prevent="$emit('switch', null)">Close</a>-->
-
-      <!-- <a :href="`${embedPoint}${icon.mode}/${icon.name}.svg`" class="btn --secondary" download>Download .svg</a> -->
+      <a
+        class="IconSelection_close"
+        href="#"
+        @click.prevent="$emit('switch', null)"
+        ><SwagIcon icon="plus" type="regular"
+      /></a>
 
       <div class="flex flex-col gap-4">
         <div class="flex gap-4 items-center">
@@ -30,6 +33,12 @@
 
     <div>
       <textarea class="form-control" v-model="exampleHTML"></textarea>
+      <a
+        :href="`${embedPoint}${icon.mode}/${icon.name}.svg`"
+        class="btn --secondary"
+        download
+        >Download svg</a
+      >
     </div>
 
     <div>
@@ -46,7 +55,6 @@
     </div>
   </div>
 </template>
-
 
 <script setup>
 import { computed } from "vue";
@@ -107,8 +115,9 @@ const embedPoint = "/resources/meteor-icon-kit/public/icons/";
   position: absolute;
   right: 0;
   top: 0;
-  margin-right: 2rem;
-  margin-top: 2rem;
+  margin-right: 1rem;
+  margin-top: 1rem;
+  rotate: 45deg;
 }
 
 .IconSelection_list {
@@ -120,6 +129,10 @@ const embedPoint = "/resources/meteor-icon-kit/public/icons/";
 .IconSelection_sidebar-bg {
   padding: 1.5rem;
   background-color: var(--sw-c-gray-50);
+}
+
+.form-control {
+  margin-bottom: 1rem;
 }
 
 .dark .IconSelection_sidebar-bg {

--- a/src/components/icons/Search.vue
+++ b/src/components/icons/Search.vue
@@ -1,0 +1,84 @@
+<template>
+  <SwagLanding>
+    <template #title>Meteor icon kit</template>
+    <template #description>An icon library and toolkit that follows a minimal, yet highly expressive style perfectly
+      aligned with Shopware's product language.
+    </template>
+  </SwagLanding>
+
+  <div class="search-container">
+    <div class="search-bar">
+      <input class="form-control" name="searchbar" type="text" @input="debounceInput" placeholder="Search icons..."/>
+
+      <div class="flex gap-4">
+        <button id="regular" class="btn --with-border" :class="[ mode === 'regular' ? '--subtle-2' : '--subtle' ]" aria-label="Regular"
+                @click="mode = 'regular'">
+          <SwagIcon icon="bell" />
+          Regular
+        </button>
+        <button id="solid" class="btn --with-border" :class="[ mode === 'solid' ? '--subtle-2' : '--subtle' ]" aria-label="Solid"
+                @click="mode = 'solid'">
+          <SwagIcon icon="bell" type="solid" />
+          Solid
+        </button>
+      </div>
+    </div>
+
+    <SearchResult :phrase="phrase" :mode="mode"/>
+  </div>
+</template>
+
+<script setup>
+import SearchResult from './SearchResult.vue';
+import { ref } from 'vue'
+
+const phrase = ref('');
+const debounce = ref(null);
+const mode = ref('regular');
+
+const debounceInput = (event) => {
+  clearTimeout(debounce.value);
+
+  debounce.value = setTimeout(() => {
+    phrase.value = event.target.value;
+  }, 600)
+}
+</script>
+
+<style lang="scss">
+@import "../public/icons/meteor-icon-kit.scss";
+
+.search-container {
+  display: flex;
+  align-content: center;
+  flex-direction: column;
+  width: 100%;
+  max-width: none;
+}
+
+.search-bar {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin: 48px auto;
+  background-size: 15px 15px;
+  font-size: 16px;
+  border: none;
+  border-radius: 8px;
+  flex-wrap: wrap;
+  gap: 48px;
+
+  @media (min-width: 960.5px) {
+    .btn {
+      @apply justify-center;
+      width: 11.5rem;
+    }
+  }
+}
+
+.search-bar input {
+  flex: 1;
+  background: transparent url("/resources/meteor-icon-kit/public/icons/regular/search.svg") no-repeat calc(100% - 15px) center;
+  background-size: 1rem;
+}
+</style>

--- a/src/components/icons/Search.vue
+++ b/src/components/icons/Search.vue
@@ -1,52 +1,62 @@
 <template>
-  <SwagLanding>
-    <template #title>Meteor icon kit</template>
-    <template #description>An icon library and toolkit that follows a minimal, yet highly expressive style perfectly
-      aligned with Shopware's product language.
-    </template>
-  </SwagLanding>
-
   <div class="search-container">
     <div class="search-bar">
-      <input class="form-control" name="searchbar" type="text" @input="debounceInput" placeholder="Search icons..."/>
+      <input
+        class="form-control"
+        name="searchbar"
+        type="text"
+        @input="debounceInput"
+        placeholder="Search icons..."
+      />
 
       <div class="flex gap-4">
-        <button id="regular" class="btn --with-border" :class="[ mode === 'regular' ? '--subtle-2' : '--subtle' ]" aria-label="Regular"
-                @click="mode = 'regular'">
+        <button
+          id="regular"
+          class="btn --with-border"
+          :class="[mode === 'regular' ? '--subtle-2' : '--subtle']"
+          aria-label="Regular"
+          @click="mode = 'regular'"
+        >
           <SwagIcon icon="bell" />
           Regular
         </button>
-        <button id="solid" class="btn --with-border" :class="[ mode === 'solid' ? '--subtle-2' : '--subtle' ]" aria-label="Solid"
-                @click="mode = 'solid'">
+        <button
+          id="solid"
+          class="btn --with-border"
+          :class="[mode === 'solid' ? '--subtle-2' : '--subtle']"
+          aria-label="Solid"
+          @click="mode = 'solid'"
+        >
           <SwagIcon icon="bell" type="solid" />
           Solid
         </button>
       </div>
     </div>
 
-    <SearchResult :phrase="phrase" :mode="mode"/>
+    <SearchResult :phrase="phrase" :mode="mode" />
   </div>
 </template>
 
 <script setup>
-import SearchResult from './SearchResult.vue';
-import { ref } from 'vue'
+import SearchResult from "./SearchResult.vue";
+import { ref } from "vue";
 
-const phrase = ref('');
+const phrase = ref("");
 const debounce = ref(null);
-const mode = ref('regular');
+const mode = ref("regular");
 
 const debounceInput = (event) => {
   clearTimeout(debounce.value);
 
   debounce.value = setTimeout(() => {
     phrase.value = event.target.value;
-  }, 600)
-}
+  }, 600);
+};
 </script>
 
 <style lang="scss">
-@import "../public/icons/meteor-icon-kit.scss";
+// @import "../public/icons/meteor-icon-kit.scss";
+@import "@shopware-ag/meteor-icon-kit/icons/meteor-icon-kit.scss";
 
 .search-container {
   display: flex;
@@ -78,7 +88,9 @@ const debounceInput = (event) => {
 
 .search-bar input {
   flex: 1;
-  background: transparent url("/resources/meteor-icon-kit/public/icons/regular/search.svg") no-repeat calc(100% - 15px) center;
+  background: transparent
+    url("/resources/meteor-icon-kit/public/icons/regular/search.svg") no-repeat
+    calc(100% - 15px) center;
   background-size: 1rem;
 }
 </style>

--- a/src/components/icons/Search.vue
+++ b/src/components/icons/Search.vue
@@ -54,8 +54,7 @@ const debounceInput = (event) => {
 };
 </script>
 
-<style lang="scss">
-// @import "../public/icons/meteor-icon-kit.scss";
+<style lang="css">
 @import "@shopware-ag/meteor-icon-kit/icons/meteor-icon-kit.scss";
 
 .search-container {
@@ -77,20 +76,18 @@ const debounceInput = (event) => {
   border-radius: 8px;
   flex-wrap: wrap;
   gap: 48px;
+}
 
-  @media (min-width: 960.5px) {
-    .btn {
-      @apply justify-center;
-      width: 11.5rem;
-    }
+@media (min-width: 960.5px) {
+  .search-bar .btn {
+    justify-content: center;
+    width: 11.5rem;
   }
 }
 
 .search-bar input {
   flex: 1;
-  background: transparent
-    url("/resources/meteor-icon-kit/public/icons/regular/search.svg") no-repeat
-    calc(100% - 15px) center;
+  background: transparent url("/resources/meteor-icon-kit/public/icons/regular/search.svg") no-repeat calc(100% - 15px) center;
   background-size: 1rem;
 }
 </style>

--- a/src/components/icons/Search.vue
+++ b/src/components/icons/Search.vue
@@ -54,7 +54,7 @@ const debounceInput = (event) => {
 };
 </script>
 
-<style lang="css">
+<style lang="css" scoped>
 @import "@shopware-ag/meteor-icon-kit/icons/meteor-icon-kit.scss";
 
 .search-container {

--- a/src/components/icons/SearchResult.vue
+++ b/src/components/icons/SearchResult.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="SearchResult">
+    <div class="SearchResult_list">
+      <IconDisplay
+          v-for="icon in resultIcons"
+          :icon="icon"
+          :key="icon"
+          @select="selectedIcon = icon"/>
+    </div>
+
+    <div v-if="selectedIcon" class="SearchResult_sidebar">
+      <IconSelection :icon="selectedIcon"
+                     @switch="switchSelectedIcon"
+                     :icons="icons"/>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import IconDisplay from './IconDisplay.vue';
+import {ref, computed} from "vue";
+import Fuse from 'fuse.js'
+import IconSelection from "./IconSelection.vue";
+
+// context of the developer portal
+import meta from "../public/icons/meta.json";
+
+const icons = ref(meta);
+
+const selectedIcon = ref(null);
+
+const props = defineProps({
+  phrase: String,
+  mode: 'solid' | 'regular',
+})
+
+const resultIcons = computed(() => {
+  const filteredIcons = icons.value.filter(i => i.mode === props.mode);
+  if (props.phrase.length <= 0) {
+    return filteredIcons;
+  }
+
+  const fuse = new Fuse(filteredIcons, {
+    keys: ['name']
+  });
+
+  const searchResult = fuse.search(props.phrase);
+
+  return searchResult.map(r => r.item);
+})
+
+const switchSelectedIcon = (data) => {
+  if (!data) {
+    selectedIcon.value = null;
+    return;
+  }
+  const {basename, size, mode} = data;
+  selectedIcon.value = icons.value.find(icon => icon.basename === basename && icon.size === size && icon.mode === mode)
+}
+</script>
+
+<style lang="scss">
+.SearchResult {
+  @apply flex gap-12;
+  flex-wrap: nowrap;
+
+  &_list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: flex-start;
+    gap: 24px;
+    row-gap: 2rem;
+    flex-wrap: wrap;
+    flex-grow: 1;
+  }
+
+  &_sidebar {
+    @media (min-width: 960.5px) {
+      flex-basis: 24rem;
+      flex-grow: 0;
+      flex-shrink: 0;
+      position: relative;
+    }
+  }
+}
+</style>

--- a/src/components/icons/SearchResult.vue
+++ b/src/components/icons/SearchResult.vue
@@ -18,7 +18,6 @@
     </div>
   </div>
 </template>
-
 <script setup>
 import IconDisplay from "./IconDisplay.vue";
 import { ref, computed } from "vue";
@@ -26,10 +25,7 @@ import Fuse from "fuse.js";
 import IconSelection from "./IconSelection.vue";
 import meta from "../../../node_modules/@shopware-ag/meteor-icon-kit/icons/meta.json";
 
-// console.log(meta);
-
 const icons = ref(meta);
-
 const selectedIcon = ref(null);
 
 const props = defineProps({
@@ -65,30 +61,31 @@ const switchSelectedIcon = (data) => {
 };
 </script>
 
-<style lang="scss">
+<style lang="css">
 .SearchResult {
-  @apply flex gap-12;
+  display: flex;
+  gap: 12px;
   flex-wrap: nowrap;
+}
 
-  &_list {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
-    flex-direction: row;
-    justify-content: space-evenly;
-    align-items: flex-start;
-    gap: 24px;
-    row-gap: 2rem;
-    flex-wrap: wrap;
-    flex-grow: 1;
-  }
+.SearchResult_list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+  flex-direction: row;
+  justify-content: space-evenly;
+  align-items: flex-start;
+  gap: 24px;
+  row-gap: 2rem;
+  flex-wrap: wrap;
+  flex-grow: 1;
+}
 
-  &_sidebar {
-    @media (min-width: 960.5px) {
-      flex-basis: 24rem;
-      flex-grow: 0;
-      flex-shrink: 0;
-      position: relative;
-    }
+@media (min-width: 960.5px) {
+  .SearchResult_sidebar {
+    flex-basis: 24rem;
+    flex-grow: 0;
+    flex-shrink: 0;
+    position: relative;
   }
 }
 </style>

--- a/src/components/icons/SearchResult.vue
+++ b/src/components/icons/SearchResult.vue
@@ -23,7 +23,7 @@ import IconDisplay from "./IconDisplay.vue";
 import { ref, computed } from "vue";
 import Fuse from "fuse.js";
 import IconSelection from "./IconSelection.vue";
-import meta from "../../../node_modules/@shopware-ag/meteor-icon-kit/icons/meta.json";
+import meta from "@shopware-ag/meteor-icon-kit/icons/meta.json";
 
 const icons = ref(meta);
 const selectedIcon = ref(null);
@@ -61,7 +61,7 @@ const switchSelectedIcon = (data) => {
 };
 </script>
 
-<style lang="css">
+<style lang="css" scoped>
 .SearchResult {
   display: flex;
   gap: 12px;

--- a/src/components/icons/SearchResult.vue
+++ b/src/components/icons/SearchResult.vue
@@ -2,28 +2,31 @@
   <div class="SearchResult">
     <div class="SearchResult_list">
       <IconDisplay
-          v-for="icon in resultIcons"
-          :icon="icon"
-          :key="icon"
-          @select="selectedIcon = icon"/>
+        v-for="icon in resultIcons"
+        :icon="icon"
+        :key="icon"
+        @select="selectedIcon = icon"
+      />
     </div>
 
     <div v-if="selectedIcon" class="SearchResult_sidebar">
-      <IconSelection :icon="selectedIcon"
-                     @switch="switchSelectedIcon"
-                     :icons="icons"/>
+      <IconSelection
+        :icon="selectedIcon"
+        @switch="switchSelectedIcon"
+        :icons="icons"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
-import IconDisplay from './IconDisplay.vue';
-import {ref, computed} from "vue";
-import Fuse from 'fuse.js'
+import IconDisplay from "./IconDisplay.vue";
+import { ref, computed } from "vue";
+import Fuse from "fuse.js";
 import IconSelection from "./IconSelection.vue";
+import meta from "../../../node_modules/@shopware-ag/meteor-icon-kit/icons/meta.json";
 
-// context of the developer portal
-import meta from "../public/icons/meta.json";
+// console.log(meta);
 
 const icons = ref(meta);
 
@@ -31,32 +34,35 @@ const selectedIcon = ref(null);
 
 const props = defineProps({
   phrase: String,
-  mode: 'solid' | 'regular',
-})
+  mode: "solid" | "regular",
+});
 
 const resultIcons = computed(() => {
-  const filteredIcons = icons.value.filter(i => i.mode === props.mode);
+  const filteredIcons = icons.value.filter((i) => i.mode === props.mode);
   if (props.phrase.length <= 0) {
     return filteredIcons;
   }
 
   const fuse = new Fuse(filteredIcons, {
-    keys: ['name']
+    keys: ["name"],
   });
 
   const searchResult = fuse.search(props.phrase);
 
-  return searchResult.map(r => r.item);
-})
+  return searchResult.map((r) => r.item);
+});
 
 const switchSelectedIcon = (data) => {
   if (!data) {
     selectedIcon.value = null;
     return;
   }
-  const {basename, size, mode} = data;
-  selectedIcon.value = icons.value.find(icon => icon.basename === basename && icon.size === size && icon.mode === mode)
-}
+  const { basename, size, mode } = data;
+  selectedIcon.value = icons.value.find(
+    (icon) =>
+      icon.basename === basename && icon.size === size && icon.mode === mode
+  );
+};
 </script>
 
 <style lang="scss">

--- a/src/components/icons/SearchResult.vue
+++ b/src/components/icons/SearchResult.vue
@@ -18,6 +18,7 @@
     </div>
   </div>
 </template>
+
 <script setup>
 import IconDisplay from "./IconDisplay.vue";
 import { ref, computed } from "vue";

--- a/src/icons/index.md
+++ b/src/icons/index.md
@@ -1,0 +1,21 @@
+---
+pageClass: p-icons
+sidebar: false
+aside: false
+page: true
+#footer: false
+editLink: false
+stackOverflowLink: false
+prev: false
+next: false
+---
+
+<script setup>
+import Search from "../components/icons/Search.vue";
+</script>
+
+# Icons
+
+An icon library and toolkit that follows a minimal, yet highly expressive style perfectly aligned with Shopware's product language.
+
+<Search/>


### PR DESCRIPTION
## What
Adding documentation for meteor icon kit to shopware.design

## Why 
Devs using meteor have reported frequently searching for icons, this pr adds them to shopware.design to make them easier to find.

## How
I've include a clone of the components from the icon kit into shopware.design

