### PR TITLE
fix: storybook iframe component ids

### DIFF
--- a/src/meteor-components/content/mt-text.md
+++ b/src/meteor-components/content/mt-text.md
@@ -28,4 +28,4 @@ import { MtText } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="content" component="mt-text"></SwagStorybookIframe>
+<SwagStorybookIframe group="content" component="text"></SwagStorybookIframe>

--- a/src/meteor-components/feedback-indicator/mt-banner.md
+++ b/src/meteor-components/feedback-indicator/mt-banner.md
@@ -28,4 +28,4 @@ import { MtBanner } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="feedback-indicator" component="mt-banner"></SwagStorybookIframe>
+<SwagStorybookIframe group="feedback-indicator" component="banner"></SwagStorybookIframe>

--- a/src/meteor-components/feedback-indicator/mt-loader.md
+++ b/src/meteor-components/feedback-indicator/mt-loader.md
@@ -28,4 +28,4 @@ import { MtLoader } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="feedback-indicator" component="mt-loader"></SwagStorybookIframe>
+<SwagStorybookIframe group="feedback-indicator" component="loader"></SwagStorybookIframe>

--- a/src/meteor-components/feedback-indicator/mt-progress-bar.md
+++ b/src/meteor-components/feedback-indicator/mt-progress-bar.md
@@ -28,4 +28,4 @@ import { MtProgressBar } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="feedback-indicator" component="mt-progress-bar"></SwagStorybookIframe>
+<SwagStorybookIframe group="feedback-indicator" component="progress-bar"></SwagStorybookIframe>

--- a/src/meteor-components/feedback-indicator/mt-skeleton-bar.md
+++ b/src/meteor-components/feedback-indicator/mt-skeleton-bar.md
@@ -28,4 +28,4 @@ import { MtSkeletonBar } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="feedback-indicator" component="mt-skeleton-bar"></SwagStorybookIframe>
+<SwagStorybookIframe group="feedback-indicator" component="skeleton-bar"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-button.md
+++ b/src/meteor-components/form/mt-button.md
@@ -28,4 +28,4 @@ import { MtButton } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-button"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="button"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-checkbox.md
+++ b/src/meteor-components/form/mt-checkbox.md
@@ -28,4 +28,4 @@ import { MtCheckbox } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-checkbox"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="checkbox"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-colorpicker.md
+++ b/src/meteor-components/form/mt-colorpicker.md
@@ -28,4 +28,4 @@ import { MtColorpicker } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-colorpicker"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="colorpicker"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-datepicker.md
+++ b/src/meteor-components/form/mt-datepicker.md
@@ -28,4 +28,4 @@ import { MtDatepicker } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-datepicker"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="datepicker"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-email-field.md
+++ b/src/meteor-components/form/mt-email-field.md
@@ -28,4 +28,4 @@ import { MtEmailField } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-email-field"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="email-field"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-help-text.md
+++ b/src/meteor-components/form/mt-help-text.md
@@ -28,4 +28,4 @@ import { MtHelptext } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-help-text"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="help-text"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-number-field.md
+++ b/src/meteor-components/form/mt-number-field.md
@@ -28,4 +28,4 @@ import { MtNumberField } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-number-field"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="number-field"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-password-field.md
+++ b/src/meteor-components/form/mt-password-field.md
@@ -28,4 +28,4 @@ import { MtPasswordfield } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-password-field"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="password-field"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-select.md
+++ b/src/meteor-components/form/mt-select.md
@@ -28,4 +28,4 @@ import { MtSelect } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-select"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="select"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-slider.md
+++ b/src/meteor-components/form/mt-slider.md
@@ -28,4 +28,4 @@ import { MtSlider } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-slider"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="slider"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-switch.md
+++ b/src/meteor-components/form/mt-switch.md
@@ -28,4 +28,4 @@ import { MtSwitch } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-switch"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="switch"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-text-field.md
+++ b/src/meteor-components/form/mt-text-field.md
@@ -28,4 +28,4 @@ import { MtTextfield } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-text-field"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="text-field"></SwagStorybookIframe>

--- a/src/meteor-components/form/mt-textarea.md
+++ b/src/meteor-components/form/mt-textarea.md
@@ -28,4 +28,4 @@ import { MtTextarea } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="form" component="mt-textarea"></SwagStorybookIframe>
+<SwagStorybookIframe group="form" component="textarea"></SwagStorybookIframe>

--- a/src/meteor-components/layout/mt-card.md
+++ b/src/meteor-components/layout/mt-card.md
@@ -28,4 +28,4 @@ import { MtCard } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="layout" component="mt-card"></SwagStorybookIframe>
+<SwagStorybookIframe group="layout" component="card"></SwagStorybookIframe>

--- a/src/meteor-components/layout/mt-empty-state.md
+++ b/src/meteor-components/layout/mt-empty-state.md
@@ -28,4 +28,4 @@ import { MtEmptyState } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="layout" component="mt-empty-state"></SwagStorybookIframe>
+<SwagStorybookIframe group="layout" component="empty-state"></SwagStorybookIframe>

--- a/src/meteor-components/navigation/mt-link.md
+++ b/src/meteor-components/navigation/mt-link.md
@@ -28,4 +28,4 @@ import { MtLink } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="navigation" component="mt-link"></SwagStorybookIframe>
+<SwagStorybookIframe group="navigation" component="link"></SwagStorybookIframe>

--- a/src/meteor-components/navigation/mt-search.md
+++ b/src/meteor-components/navigation/mt-search.md
@@ -28,4 +28,4 @@ import { MtSearch } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="navigation" component="mt-search"></SwagStorybookIframe>
+<SwagStorybookIframe group="navigation" component="search"></SwagStorybookIframe>

--- a/src/meteor-components/navigation/mt-tabs.md
+++ b/src/meteor-components/navigation/mt-tabs.md
@@ -28,4 +28,4 @@ import { MtTabs } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="navigation" component="mt-tabs"></SwagStorybookIframe>
+<SwagStorybookIframe group="navigation" component="tabs"></SwagStorybookIframe>

--- a/src/meteor-components/overlay/mt-modal.md
+++ b/src/meteor-components/overlay/mt-modal.md
@@ -28,4 +28,4 @@ import { MtModal } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="overlay" component="mt-modal"></SwagStorybookIframe>
+<SwagStorybookIframe group="overlay" component="modal"></SwagStorybookIframe>

--- a/src/meteor-components/overlay/mt-popover.md
+++ b/src/meteor-components/overlay/mt-popover.md
@@ -28,4 +28,4 @@ import { MtPopover } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="overlay" component="mt-popover"></SwagStorybookIframe>
+<SwagStorybookIframe group="overlay" component="popover"></SwagStorybookIframe>

--- a/src/meteor-components/overlay/mt-tooltip.md
+++ b/src/meteor-components/overlay/mt-tooltip.md
@@ -28,4 +28,4 @@ import { MtTooltip } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="overlay" component="mt-tooltip"></SwagStorybookIframe>
+<SwagStorybookIframe group="overlay" component="tooltip"></SwagStorybookIframe>

--- a/src/meteor-components/table-list/mt-pagination.md
+++ b/src/meteor-components/table-list/mt-pagination.md
@@ -28,4 +28,4 @@ import { MtPagination } from "@shopware-ag/meteor-component-library";
 
 ## Example
 
-<SwagStorybookIframe group="table-and-list" component="mt-pagination"></SwagStorybookIframe>
+<SwagStorybookIframe group="table-and-list" component="pagination"></SwagStorybookIframe>


### PR DESCRIPTION
Hi! The Storybook example iframes are [currently broken](https://shopware.design/meteor-components/form/mt-button.html), probably due to the ID changes in https://github.com/shopware/meteor/pull/1132.

There are still two broken iframes left, as they do not have a matching Storybook entry (anymore?):
- [Field label](https://shopware.design/meteor-components/form/mt-field-label.html)
- [Segmented control](https://shopware.design/meteor-components/navigation/mt-segmented-control.html)