### PR TITLE
fix: update storybook iframe url to storybook.meteor.shopware.com

### DIFF
--- a/src/components/storybook/SwagStorybookIframe.vue
+++ b/src/components/storybook/SwagStorybookIframe.vue
@@ -24,7 +24,7 @@ const props = defineProps({
 });
 const src = computed(
   () =>
-    `https://meteor-component-library.vercel.app/?path=/docs/components-${props.component}--docs&viewMode=docs&shortcuts=false&singleStory=true&toolbar=false`
+    `https://storybook.meteor.shopware.com/?path=/docs/components-${props.component}--docs&viewMode=docs&shortcuts=false&singleStory=true&toolbar=false`
 );
 </script>
 


### PR DESCRIPTION
Should future-proof the required URL to render Storybook iframes. Not affected by Vercel project renaming anymore.